### PR TITLE
Added a Dockerfile for creating a test environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:stable
+
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get install -y build-essential curl git vim 
+RUN curl -sL https://deb.nodesource.com/setup_4.x | bash -
+RUN apt-get install -y nodejs
+RUN npm install -g cordova gulp ionic


### PR DESCRIPTION
I specifically added the Dockerfile for the Docker image which I have hosted over at Docker hub under theriddler91/ionic-framework-tutorial:latest 

The reason I created a test envrionment specifically for the tutorial is so that I don't have to manage multiple node.js version on my computer and I would rather not use a VM. 
